### PR TITLE
Simple deserialization, extended README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The NBO File Format offers a way for minecraft users to keep their configuration files simple. NBO stands for named binary objects and refers to the json like NBT format introduced by minecraft. NBO extends this format with object references. Some ressources i made require many simple objects in relation to each other. This might be easy in code but quite hard to setup for yml users. With NBO, one can simply declare NBT trees and reference them in other trees.
 
 Example:
-```
+```json
 sound := Sound{
   sound: "minecraft:entity.firework_rocket.blast", 
   volume: 1f, 
@@ -41,7 +41,7 @@ Here you can see YML and NBO in comparison for object (de-)serialisation:
 <tr>
 <td>
 
-```
+```yml
 other_effect:
     ==: SoundPlayer
     volume: 1.0
@@ -67,7 +67,7 @@ effect_player:
 </td>
 <td>
   
-```
+```json
 other_effect := SoundPlayer{
   sound: 'minecraft:entity.villager.no', 
   volume: 1.0, 
@@ -96,4 +96,30 @@ effect_player := EffectPlayer{
 </td>
 </table>
 
+## Usage
 
+To make use of this file format in your code, you must first register any classes 
+that are used in your NBOFile with the NBOSerializer. After that, you can load
+your NBOFile and retrieve the values that you need. You can also take a look at the
+test cases, where this example originates from and where you can also see the
+(de-)serialization methods for this example class as well as the corresponding source nbo
+file (`vector_test.nbo`).
+```java
+// registration must be done for every class that you want to deserialize once before first usage
+NBOSerializer.register(
+        Vecto3f.class,
+        Vector3f::deserialize,  // Function<Map<String, ?>, T>
+        Vector3f::serialize     // Function<T, Map<String, Object>>
+);
+NBOSerializer.register(
+        Matrix3f.class,
+        Matrix3f::deserialize,
+        Matrix3f::serialize
+);
+
+File file = /*...*/; // load your file
+NBOFile nbo = NBOFile.loadFile(file);
+
+Vector3f vector = nbo.get("vec"); // note that this might throw in a class cast exception
+Matrix3f matrix = nbo.get("matrix");
+```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The NBO File Format offers a way for minecraft users to keep their configuration files simple. NBO stands for named binary objects and refers to the json like NBT format introduced by minecraft. NBO extends this format with object references. Some ressources i made require many simple objects in relation to each other. This might be easy in code but quite hard to setup for yml users. With NBO, one can simply declare NBT trees and reference them in other trees.
 
 Example:
-```json
+```
 sound := Sound{
   sound: "minecraft:entity.firework_rocket.blast", 
   volume: 1f, 
@@ -67,7 +67,7 @@ effect_player:
 </td>
 <td>
   
-```json
+```
 other_effect := SoundPlayer{
   sound: 'minecraft:entity.villager.no', 
   volume: 1.0, 

--- a/src/main/java/nbo/NBOFile.java
+++ b/src/main/java/nbo/NBOFile.java
@@ -45,9 +45,16 @@ public class NBOFile {
         new NBOInterpreter().interpret(file.root);
 
         NBOMap objects = (NBOMap) file.root.get(KEY_OBJECTS);
+        NBOMap imports = (NBOMap) file.root.get(KEY_IMPORTS);
+
+        NBOSerializationContext context = new NBOSerializationContext();
+        imports.forEach((s, nboTree) -> context.getClassImports().put(s, ((NBOString) nboTree).getValueRaw()));
+
         for (var entry : objects.entrySet()) {
             NBOObject object = (NBOObject) entry.getValue();
-            file.objectMap.put(entry.getKey(), NBOSerializer.deserialize(object));
+            Object deserialized = NBOSerializer.deserialize(object, context);
+            file.objectMap.put(entry.getKey(), deserialized);
+            context.getReferenceObjects().put(entry.getKey(), deserialized);
         }
         return file;
     }

--- a/src/main/java/nbo/NBOSerializationContext.java
+++ b/src/main/java/nbo/NBOSerializationContext.java
@@ -1,0 +1,14 @@
+package nbo;
+
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+public class NBOSerializationContext {
+
+    private final Map<String, String> classImports = new HashMap<>();
+    private final Map<String, Object> referenceObjects = new HashMap<>();
+
+}

--- a/src/main/java/nbo/NBOSerializer.java
+++ b/src/main/java/nbo/NBOSerializer.java
@@ -8,112 +8,149 @@ import java.util.stream.Collectors;
 
 public class NBOSerializer {
 
-	public interface ConvertTo {
-		Map<String, Object> convert(Object o);
-	}
+    public interface ConvertTo {
+        Map<String, Object> convert(Object o);
+    }
 
-	public interface ConvertFrom {
-		Object convert(Map<String, Object> map);
-	}
+    public interface ConvertFrom {
+        Object convert(Map<String, ? extends Object> map);
+    }
 
-	public record Serializer(Class<?> clazz, ConvertFrom from, ConvertTo to) {
-	}
+    public record Serializer(Class<?> clazz, ConvertFrom from, ConvertTo to) {
+    }
 
-	private static final Collection<Serializer> SERIALIZABLES = new HashSet<>();
+    private static final Collection<Serializer> SERIALIZABLES = new HashSet<>();
 
-	public static Map<String, Object> convertAstToMap(NBOMap input) throws ClassNotFoundException {
-		return (Map<String, Object>) convertAstToObject(input);
-	}
+    public static Map<String, Object> convertAstToMap(NBOMap input) throws ClassNotFoundException {
+        return (Map<String, Object>) convertAstToObject(input);
+    }
 
-	public static Object convertAstToObject(NBOTree input) throws ClassNotFoundException {
-		if (input instanceof NBOObject object) {
-			return deserialize(object);
-		} else if (input instanceof NBOMap map) {
-			return new LinkedHashMap<>(map.entrySet().stream().map(e -> {
-				try {
-					return new AbstractMap.SimpleEntry<>(e.getKey(), convertAstToObject(e.getValue()));
-				} catch (ClassNotFoundException ex) {
-					ex.printStackTrace();
-				}
-				return null;
-			}).filter(Objects::nonNull).collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue)));
-		} else if (input instanceof NBOList list) {
-			return list.stream().map(e -> {
-				try {
-					return convertAstToObject(e);
-				} catch (ClassNotFoundException ex) {
-					ex.printStackTrace();
-				}
-				return null;
-			}).distinct().collect(Collectors.toCollection(ArrayList::new));
-		} else if (input instanceof NBOString string) {
-			return string.getValue();
-		}
-		return null;
-	}
+    public static Object convertAstToObject(NBOTree input) throws ClassNotFoundException {
+        if (input instanceof NBOObject object) {
+            return deserialize(object);
+        } else if (input instanceof NBOMap map) {
+            return new LinkedHashMap<>(map.entrySet().stream().map(e -> {
+                try {
+                    return new AbstractMap.SimpleEntry<>(e.getKey(), convertAstToObject(e.getValue()));
+                } catch (ClassNotFoundException ex) {
+                    ex.printStackTrace();
+                }
+                return null;
+            }).filter(Objects::nonNull).collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue)));
+        } else if (input instanceof NBOList list) {
+            return list.stream().map(e -> {
+                try {
+                    return convertAstToObject(e);
+                } catch (ClassNotFoundException ex) {
+                    ex.printStackTrace();
+                }
+                return null;
+            }).distinct().collect(Collectors.toCollection(ArrayList::new));
+        } else if (input instanceof NBOString string) {
+            return string.getValue();
+        }
+        return null;
+    }
 
 
-	public static NBOMap convertMapToAST(Map<String, Object> input) {
-		return (NBOMap) convertObjectToAst(input);
-	}
+    public static NBOMap convertMapToAST(Map<String, Object> input) {
+        return (NBOMap) convertObjectToAst(input);
+    }
 
-	public static NBOTree convertObjectToAst(Object input) {
-		Serializer serializer = SERIALIZABLES.stream().filter(s -> s.clazz.equals(input.getClass())).findFirst().orElse(null);
-		if (serializer != null) {
-			NBOObject object = new NBOObject(input.getClass().getName());
-			object.putAll(serializer.to().convert(input).entrySet().stream()
-					.map(e -> new AbstractMap.SimpleEntry<>(e.getKey(), convertObjectToAst(e.getValue())))
-					.collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue)));
-			return object;
+    public static NBOTree convertObjectToAst(Object input) {
+        Serializer serializer = SERIALIZABLES.stream().filter(s -> s.clazz.equals(input.getClass())).findFirst().orElse(null);
+        if (serializer != null) {
+            NBOObject object = new NBOObject(input.getClass().getName());
+            object.putAll(serializer.to().convert(input).entrySet().stream()
+                    .map(e -> new AbstractMap.SimpleEntry<>(e.getKey(), convertObjectToAst(e.getValue())))
+                    .collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue)));
+            return object;
 
-		} else if (input instanceof String string) {
-			return new NBOString(string);
-		} else if (input instanceof Integer integer) {
-			return new NBOInteger(integer);
-		} else if (input instanceof Boolean bool) {
-			return new NBOBool(bool);
-		} else if (input instanceof Float val) {
-			return new NBOFloat(val);
-		} else if (input instanceof Map) {
-			Map<String, Object> map = (Map<String, Object>) input;
-			var m = new NBOMap();
-			m.putAll(map.entrySet().stream()
-					.map(e -> new AbstractMap.SimpleEntry<>(e.getKey(), convertObjectToAst(e.getValue())))
-					.collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue)));
-			return m;
-		} else if (input instanceof List list) {
-			var l = new NBOList();
-			l.addAll(list);
-			return l;
-		}
-		return null;
-	}
+        } else if (input instanceof String string) {
+            return new NBOString(string);
+        } else if (input instanceof Integer integer) {
+            return new NBOInteger(integer);
+        } else if (input instanceof Boolean bool) {
+            return new NBOBool(bool);
+        } else if (input instanceof Float val) {
+            return new NBOFloat(val);
+        } else if (input instanceof Map) {
+            Map<String, Object> map = (Map<String, Object>) input;
+            var m = new NBOMap();
+            m.putAll(map.entrySet().stream()
+                    .map(e -> new AbstractMap.SimpleEntry<>(e.getKey(), convertObjectToAst(e.getValue())))
+                    .collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue)));
+            return m;
+        } else if (input instanceof List list) {
+            var l = new NBOList();
+            l.addAll(list);
+            return l;
+        }
+        return null;
+    }
 
-	public static <T> T deserialize(String objectString) throws ClassNotFoundException {
-		return null; //TODO
-	}
+    public static <T> T deserialize(String objectString) throws ClassNotFoundException {
+        return null; //TODO
+    }
 
-	public static <T> T deserialize(NBOObject object) throws ClassNotFoundException {
-		return null; //TODO
-	}
+    public static <T> T deserialize(NBOObject object, NBOSerializationContext context) throws ClassNotFoundException {
+        String className = context.getClassImports().getOrDefault(object.getType(), object.getType());
+        Class<?> clazz = Class.forName(className);
+        Serializer serializer = SERIALIZABLES.stream()
+                .filter(s -> s.clazz.equals(clazz))
+                .findFirst()
+                .orElse(null);
+        if (serializer == null) {
+            throw new RuntimeException("Class not registered for serialization: " + clazz.getName());
+        }
+        Map<String, Object> actualValues = new HashMap<>();
+        for (Map.Entry<String, NBOTree> entry : object.entrySet()) {
+            actualValues.put(entry.getKey(), deserialize(entry.getValue()));
+        }
+        for (Map.Entry<String, Object> entry : actualValues.entrySet()) {
+            if (entry.getValue() instanceof NBOReference reference) {
+                String referenceName = reference.getValueRaw();
+                Object actualValue = context.getReferenceObjects().get(referenceName);
+                entry.setValue(actualValue);
+            }
+        }
+        return (T) serializer.from().convert(actualValues);
+    }
 
-	public static <T> void register(Class<T> serializable, Function<Map<String, Object>, T> to, Function<T, Map<String, Object>> from) {
-		SERIALIZABLES.add(new Serializer(serializable, to::apply, o -> from.apply((T) o)));
-	}
+    public static <T> T deserialize(NBOTree nboTree) throws ClassNotFoundException {
+        if (nboTree instanceof NBOBool nboBool) {
+            return (T) nboBool.getValueRaw();
+        } else if (nboTree instanceof NBOFloat nboFloat) {
+            return (T) nboFloat.getValueRaw();
+        } else if (nboTree instanceof NBOInteger nboInteger) {
+            return (T) nboInteger.getValueRaw();
+        } else if (nboTree instanceof NBOString nboString) {
+            return (T) nboString.getValueRaw();
+        } else if (nboTree instanceof NBOReference nboReference) {
+            return (T) nboReference;
+        } else if (nboTree instanceof NBOObject nboObject) {
+            return deserialize(nboObject);
+        }
+        throw new RuntimeException("Could not unpack NBOTree object: " + nboTree);
+    }
 
-	public static void unregister(Class<?> serializable) {
-		SERIALIZABLES.removeAll(SERIALIZABLES.stream().filter(nboSerializer -> nboSerializer.clazz.equals(serializable)).collect(Collectors.toSet()));
-	}
+    public static <T> void register(Class<T> serializable, Function<Map<String, ?>, T> to, Function<T, Map<String, Object>> from) {
+        SERIALIZABLES.add(new Serializer(serializable, to::apply, o -> from.apply((T) o)));
+    }
 
-	public static Map<String, Object> serialize(Object object) {
-		if (object instanceof NBOSerializable serializable) {
-			return serializable.serialize();
-		}
-		Serializer serializer = SERIALIZABLES.stream().filter(s -> s.clazz.equals(object.getClass())).findFirst().orElse(null);
-		if (serializer != null) {
-			return serializer.to().convert(object);
-		}
-		throw new IllegalArgumentException("Input object " + object.getClass() + " must either be registered as Serializable or implement NBOSerializable interface.");
-	}
+    public static void unregister(Class<?> serializable) {
+        SERIALIZABLES.removeAll(SERIALIZABLES.stream().filter(nboSerializer -> nboSerializer.clazz.equals(serializable)).collect(Collectors.toSet()));
+    }
+
+    public static Map<String, Object> serialize(Object object) {
+        if (object instanceof NBOSerializable serializable) {
+            return serializable.serialize();
+        }
+        Serializer serializer = SERIALIZABLES.stream().filter(s -> s.clazz.equals(object.getClass())).findFirst().orElse(null);
+        if (serializer != null) {
+            return serializer.to().convert(object);
+        }
+        throw new IllegalArgumentException("Input object " + object.getClass() + " must either be registered as Serializable or implement NBOSerializable interface.");
+    }
 
 }

--- a/src/main/java/nbo/tree/NBOBool.java
+++ b/src/main/java/nbo/tree/NBOBool.java
@@ -32,6 +32,11 @@ public class NBOBool implements NBOTree {
     }
 
     @Override
+    public Object getValueRaw() {
+        return value;
+    }
+
+    @Override
     public List<NBOTree> getSubTrees() {
         return new ArrayList<>();
     }

--- a/src/main/java/nbo/tree/NBOFloat.java
+++ b/src/main/java/nbo/tree/NBOFloat.java
@@ -26,7 +26,13 @@ public class NBOFloat implements NBOTree {
         return getValue().toString();
     }
 
+    @Override
     public Object getValue() {
+        return value;
+    }
+
+    @Override
+    public Object getValueRaw() {
         return value;
     }
 

--- a/src/main/java/nbo/tree/NBOInteger.java
+++ b/src/main/java/nbo/tree/NBOInteger.java
@@ -26,7 +26,13 @@ public class NBOInteger implements NBOTree {
         return getValue().toString();
     }
 
+    @Override
     public Object getValue() {
+        return value;
+    }
+
+    @Override
+    public Object getValueRaw() {
         return value;
     }
 

--- a/src/main/java/nbo/tree/NBOList.java
+++ b/src/main/java/nbo/tree/NBOList.java
@@ -12,6 +12,11 @@ public class NBOList extends ArrayList<NBOTree> implements NBOTree {
     }
 
     @Override
+    public Object getValueRaw() {
+        return "List";
+    }
+
+    @Override
     public List<NBOTree> getSubTrees() {
         return stream().flatMap(tree -> tree.getSubTrees().stream()).collect(Collectors.toList());
     }

--- a/src/main/java/nbo/tree/NBOMap.java
+++ b/src/main/java/nbo/tree/NBOMap.java
@@ -15,6 +15,11 @@ public class NBOMap extends LinkedHashMap<String, NBOTree> implements NBOTree {
     }
 
     @Override
+    public Object getValueRaw() {
+        return "Map";
+    }
+
+    @Override
     public List<NBOTree> getSubTrees() {
         return new ArrayList<>(values());
     }

--- a/src/main/java/nbo/tree/NBOObject.java
+++ b/src/main/java/nbo/tree/NBOObject.java
@@ -3,6 +3,7 @@ package nbo.tree;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
 @Getter
 @Setter
@@ -10,4 +11,10 @@ import lombok.Setter;
 public class NBOObject extends NBOMap {
 
     private String type;
+
+    @Override
+    public String toString() {
+        return type + "{" + super.toString() + "}";
+    }
+
 }

--- a/src/main/java/nbo/tree/NBOReference.java
+++ b/src/main/java/nbo/tree/NBOReference.java
@@ -13,12 +13,18 @@ import java.util.List;
 public class NBOReference implements NBOTree {
     private String reference;
 
-    @Override public String toString() {
+    @Override
+    public String toString() {
         return "&" + getValue();
     }
 
     @Override
-    public Object getValue() {
+    public String getValue() {
+        return reference;
+    }
+
+    @Override
+    public String getValueRaw() {
         return reference;
     }
 

--- a/src/main/java/nbo/tree/NBOString.java
+++ b/src/main/java/nbo/tree/NBOString.java
@@ -15,12 +15,18 @@ public class NBOString implements NBOTree {
         this.value = value.startsWith("'") || value.startsWith("\"") ? value.substring(1, value.length() - 1) : value;
     }
 
-    @Override public String toString() {
+    @Override
+    public String toString() {
         return (String) getValue();
     }
 
+    @Override
     public Object getValue() {
         return "'" + value + "'";
+    }
+
+    public String getValueRaw() {
+        return value;
     }
 
     @Override

--- a/src/main/java/nbo/tree/NBOTree.java
+++ b/src/main/java/nbo/tree/NBOTree.java
@@ -7,4 +7,7 @@ public interface NBOTree {
     List<NBOTree> getSubTrees();
 
     Object getValue();
+
+    Object getValueRaw();
+
 }

--- a/src/main/resources/test.nbo
+++ b/src/main/resources/test.nbo
@@ -1,6 +1,6 @@
 
 <with Tree as de.cubbossa.example.forest.Tree>
-<with GUn as de.cubbossa.example.forest.Gun>
+<with Gun as de.cubbossa.example.forest.Gun>
 
 other := Gun{size: "50"}
 

--- a/src/main/resources/vector_test.nbo
+++ b/src/main/resources/vector_test.nbo
@@ -1,0 +1,27 @@
+
+<with Vec as nbo.TokenizerTest$Vector3f>
+<with Mat as nbo.TokenizerTest$Matrix3f>
+
+unit_1 := Vec {
+    x: 1.0,
+    y: 0.0,
+    z: 0.0
+}
+
+unit_2 := Vec {
+    x: 0.f,
+    y: 1.f,
+    z: 0.f
+}
+
+unit_3 := Vec {
+    x: 0.f,
+    y: 0.f,
+    z: 1.f
+}
+
+mat := Mat {
+    col1: &unit_1,
+    col2: &unit_2,
+    col3: &unit_3,
+}

--- a/src/test/java/nbo/TokenizerTest.java
+++ b/src/test/java/nbo/TokenizerTest.java
@@ -6,10 +6,51 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 class TokenizerTest {
+
+	public record Vector3f (float x, float y, float z) {
+		public static Vector3f deserialize(Map<String, ?> map) {
+			return new Vector3f(
+					(float) map.get("x"),
+					(float) map.get("y"),
+					(float) map.get("z")
+			);
+		}
+
+		public Map<String, Object> serialize() {
+			return Map.of(
+					"x", x,
+					"y", y,
+					"z", z
+			);
+		}
+	}
+
+	public record Matrix3f (Vector3f col1, Vector3f col2, Vector3f col3) {
+		public static Matrix3f deserialize(Map<String, ?> map) {
+			return new Matrix3f(
+					(Vector3f) map.get("col1"),
+					(Vector3f) map.get("col2"),
+					(Vector3f) map.get("col3")
+			);
+		}
+
+		public Map<String, Object> serialize() {
+			return Map.of(
+					"col1", col1,
+					"col2", col2,
+					"col3", col3
+			);
+		}
+	}
 
 	private final String example1 = "<with Tree as OtherTree> assign := Type{key: '&reference', list: ['a', 'x', 'v']}";
 	private final String example2 = "<with Tree as OtherTree>\n<with Cow as Pig>\nxy := Type{key: 'a'}  assign := Type{key: &xy, other: 'xy', block: {key: 'lulu', mehr: 'hai'}, list2: [1b, 0B, true], list: ['x', {key: 'value'}, 'z', 'a', 'b']}";
+
+	private static final File TEST_FILE = new File("src/main/resources/test.nbo");
+	private static final File TEST_FILE_VECTOR = new File("src/main/resources/vector_test.nbo");
 
 	@Test
 	void tokenize() throws NBOParseException {
@@ -33,8 +74,48 @@ class TokenizerTest {
 	@Test
 	public void writeToFile() throws IOException, NBOParseException, ClassNotFoundException {
 		NBOSerializer.register(File.class, s -> new File((String) s.get("path")), f -> Map.of("path", f.getAbsolutePath()));
-		NBOFile file = NBOFile.loadFile(new File("src/main/resources/test.nbo"));
-		file.setObject("Afile", new File("src/main/resources/test.nbo"));
+		NBOFile file = NBOFile.loadFile(TEST_FILE);
+		file.setObject("a_file", TEST_FILE);
 		System.out.println(NBOFile.formatToFileString(file.getRoot()));
 	}
+
+	@Test
+	public void readFromFile() throws IOException, NBOParseException, ClassNotFoundException {
+		NBOSerializer.register(
+				Vector3f.class,
+				Vector3f::deserialize,
+				Vector3f::serialize
+		);
+		NBOSerializer.register(
+				Matrix3f.class,
+				Matrix3f::deserialize,
+				Matrix3f::serialize
+		);
+		NBOFile file = NBOFile.loadFile(TEST_FILE_VECTOR);
+
+		Vector3f unit1 = file.get("unit_1");
+		assertNotNull(unit1, "unit1 should not be null, as it should be defined in vector_test.nbo");
+		assertEquals(1.0f, unit1.x);
+		assertEquals(0.0f, unit1.y);
+		assertEquals(0.0f, unit1.z);
+
+		Vector3f unit2 = file.get("unit_2");
+		assertNotNull(unit2, "unit2 should not be null, as it should be defined in vector_test.nbo");
+		assertEquals(0.0f, unit2.x);
+		assertEquals(1.0f, unit2.y);
+		assertEquals(0.0f, unit2.z);
+
+		Vector3f unit3 = file.get("unit_3");
+		assertNotNull(unit3, "unit3 should not be null, as it should be defined in vector_test.nbo");
+		assertEquals(0.0f, unit3.x);
+		assertEquals(0.0f, unit3.y);
+		assertEquals(1.0f, unit3.z);
+
+		Matrix3f matrix3f = file.get("mat");
+		assertNotNull(matrix3f, "matrix3f should not be null, as it should be defined in vector_test.nbo");
+		assertEquals(unit1, matrix3f.col1);
+		assertEquals(unit2, matrix3f.col2);
+		assertEquals(unit3, matrix3f.col3);
+	}
+
 }


### PR DESCRIPTION
This PR introduces a NBOSerializationContext object which holds information about Objects that have been created (for referencing) as well as any imports made (to load the correct classes).

Objects for referencing are currently held in memory twice during deserialization (the file's object map as well as the context's reference map) which could be still improvised upon.

Also, the other deserialization method has not yet been implemented.

A test case demonstrating the deserialization of simple objects is provided with this PR, however a more comprehensive test case (consisting of more objects) could be implemented for further testing.

EDIT: A rather "dirty" side effect of this PR is also that the floating point regex has been changed to also accept values like "1.", "1f" and "1.f" (which was previously not possible and lead to the parser not accepting the input).